### PR TITLE
explicitly set default_plugin to 1 for default plugins

### DIFF
--- a/plugindocs.rb
+++ b/plugindocs.rb
@@ -58,10 +58,12 @@ class PluginDocs < Clamp::Command
         .gsub("%RELEASE_DATE%", date) \
         .gsub("%CHANGELOG_URL%", "https://github.com/logstash-plugins/#{repository}/blob/#{version}/CHANGELOG.md")
 
-      if !is_default_plugin
-        # Mark non-default plugins so that the docs build will know to add the
+      content = content.sub(/^:type: .*/) do |type|
+        # Mark default/non-default plugins so that the docs build will know to add the
         # "how to install this plugin" banner.
-        content = content.sub(/^:type: .*/) do |type|
+        if is_default_plugin
+          "#{type}\n:default_plugin: 1"
+        else
           "#{type}\n:default_plugin: 0"
         end
       end


### PR DESCRIPTION
because attributes are sticky and the code to identify default plugins only sets the `default_plugin` attribute if it is not default, once a plugin that is not default is found, the attribute stays at 0 for the remaining plugins, causing all plugins to have the install plugin snippet inadvertently

This PR sets the attribute to either 0 or 1 depending on it not being (or being) a default plugin.

fixes #9 