### PR TITLE
Update paths in build script

### DIFF
--- a/versioned_plugins.rb
+++ b/versioned_plugins.rb
@@ -99,6 +99,7 @@ class VersionedPluginDocs < Clamp::Command
       .gsub("%VERSION%", version) \
       .gsub("%RELEASE_DATE%", date) \
       .gsub("%CHANGELOG_URL%", "https://github.com/logstash-plugins/#{repository}/blob/#{version}/CHANGELOG.md") \
+      .gsub(":include_path: ../../../../logstash/docs/include", ":include_path: ../include/6.x") \
 
     content = content.sub(/^:type: .*/) do |type|
       "#{type}"
@@ -112,7 +113,7 @@ class VersionedPluginDocs < Clamp::Command
       content = content.gsub(/^====== /, "===== ")
         .gsub("[source]", "[source,shell]")
         .gsub('[id="plugins-{type}-{plugin}', '[id="plugins-{type}s-{plugin}')
-        .gsub(":include_path: ../../../logstash/docs/include", ":include_path: ../../../../logstash/docs/include")
+        .gsub(":include_path: ../../../logstash/docs/include", ":include_path: ../include/6.x")
 
       content = content
         .gsub("<<string,string>>", "{logstash-ref}/configuration-file-structure.html#string[string]")


### PR DESCRIPTION
@jsvd Here is the change required to get the script to generate the correct paths.

At some point, we'll need some logic for determining how to update files in /include/6.x when the files in /logstash/docs/include/change. I created a versioned directory because I didn't want old plugin docs to pick up changes if/when we add or remove things like common options. So 6.x gives us a snapshot of the files. 

Edit: By "snapshot", I mean that I manually copied the files over to the 6.x directory. :-) If we make changes in /logstash/docs/include/change that we DO want in the 6.x folder, then we'll have to copy the files manually for now.