### PR TITLE
Updates to versioned docs generation script

### DIFF
--- a/versioned_plugins.rb
+++ b/versioned_plugins.rb
@@ -113,7 +113,7 @@ class VersionedPluginDocs < Clamp::Command
 
   def test_docs
     `git clone https://github.com/elastic/docs #{docs_path}`
-    `perl #{docs_path}/docs/build_docs.pl --doc #{logstash_docs_path}/docs/versioned-plugins/index.asciidoc --chunk 1 -open`
+    `perl #{docs_path}/build_docs.pl --doc #{logstash_docs_path}/docs/versioned-plugins/index.asciidoc --chunk 1 -open`
     unless $?.success?
       puts "failed to build docs. terminating"
       exit $?.exitstatus

--- a/versioned_plugins.rb
+++ b/versioned_plugins.rb
@@ -113,7 +113,7 @@ class VersionedPluginDocs < Clamp::Command
 
   def test_docs
     `git clone https://github.com/elastic/docs #{docs_path}`
-    `perl ../docs/build_docs.pl --doc docs/versioned-plugins/index.asciidoc --chunk 1 -open`
+    `perl #{docs_path}/docs/build_docs.pl --doc #{logstash_docs_path}/docs/versioned-plugins/index.asciidoc --chunk 1 -open`
     unless $?.success?
       puts "failed to build docs. terminating"
       exit $?.exitstatus


### PR DESCRIPTION
* parallelize docs generation by creating one thread per plugin type (input/output/filter/codecs)
* add flags for testings docs and submitting PR
* redo some logging entries due to new concurrency