### PR TITLE
Added cleanup entry for string_duration

### DIFF
--- a/versioned_plugins.rb
+++ b/versioned_plugins.rb
@@ -256,8 +256,9 @@ class VersionedPluginDocs < Clamp::Command
         .gsub("<<uri,uri>>", "{logstash-ref}/configuration-file-structure.html#uri[uri]")
         .gsub("<<bytes,bytes>>", "{logstash-ref}/configuration-file-structure.html#bytes[bytes]")
         .gsub("<<event-api,Event API>>", "{logstash-ref}/event-api.html[Event API]")
-        .gsub("<<dead-letter-queues>>", '{logstash-ref}/dead-letter-queues.html[dead-letter-queues]')
+        .gsub("<<dead-letter-queues>>", "{logstash-ref}/dead-letter-queues.html[dead-letter-queues]")
         .gsub("<<logstash-config-field-references>>", "{logstash-ref}/event-dependent-configuration.html#logstash-config-field-references[Field References]")
+        .gsub("<<string_duration,string_duration>>", "{logstash-ref}/string_duration.html[string_duration]")
     end
 
     content = content.gsub('[id="plugins-', '[id="{version}-plugins-')


### PR DESCRIPTION
In https://github.com/elastic/logstash-docs/pull/616#pullrequestreview-146514641, DeDe suggested adding a cleanup entry for string_duration.  I've added the entry, but the target content does not exist at this time. 

- Content currently lives here: https://www.elastic.co/guide/en/logstash/master/plugins-inputs-file.html#plugins-inputs-file-string_duration
- Belongs here: https://www.elastic.co/guide/en/logstash/6.3/configuration-file-structure.html#plugin-value-types

DO NOT MERGE until target content is added