### PR TITLE
versioned docs: patch versioned docs for Kafka Integration v10.0.0

### DIFF
--- a/versioned_plugins.rb
+++ b/versioned_plugins.rb
@@ -347,6 +347,8 @@ class VersionedPluginDocs < Clamp::Command
       .gsub("<<plugins-#{type}s-#{name}", "<<{version}-plugins-#{type}s-#{name}")
       .gsub("[[dlq-policy]]", '[id="{version}-dlq-policy"]')
       .gsub("<<dlq-policy>>", '<<{version}-dlq-policy>>')
+      .gsub("[Kafka Input Plugin @9.1.0](https://github.com/logstash-plugins/logstash-input-rabbitmq/blob/v9.1.0/CHANGELOG.md)", "[Kafka Input Plugin @9.1.0](https://github.com/logstash-plugins/logstash-input-kafka/blob/v9.1.0/CHANGELOG.md)")
+      .gsub("[Kafka Output Plugin @8.1.0](https://github.com/logstash-plugins/logstash-output-rabbitmq/blob/v8.1.0/CHANGELOG.md)", "[Kafka Output Plugin @8.1.0](https://github.com/logstash-plugins/logstash-output-kafka/blob/v8.1.0/CHANGELOG.md)")
 
     if repair?
       content.gsub!(/<<plugins-.+?>>/) do |link|


### PR DESCRIPTION
The initial release of the Kafka Integration Plugin included links in its
changelog to the stand-alone _RabbitMQ_ plugins instead of the _Kafka_
plugins. By adding this fixup, we can ensure that versioned docs link
to the correct upstream changelogs.

See: https://github.com/logstash-plugins/logstash-integration-kafka/pull/3