### PR TITLE
reduce memory for plugin versions generation

### DIFF
--- a/build_docs.sh
+++ b/build_docs.sh
@@ -33,7 +33,7 @@ git clone --depth 1 git@github.com:elastic/docs.git
 
 cd logstash
 
-./gradlew generatePluginsVersion -Dorg.gradle.jvmargs="-Xmx12g"
+./gradlew generatePluginsVersion -Dorg.gradle.jvmargs="-Xmx4g"
 
 cd ../docs-tools
 

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -33,7 +33,10 @@ git clone --depth 1 git@github.com:elastic/docs.git
 
 cd logstash
 
-./gradlew generatePluginsVersion -Dorg.gradle.jvmargs="-Xmx4g"
+# we did not back-port https://github.com/elastic/logstash/pull/12763 to 6.8
+jvm_args="-Xmx4g" && [[ "$branch_specifier" == "6.8" ]] && jvm_args="-Xmx12g"
+
+./gradlew generatePluginsVersion -Dorg.gradle.jvmargs="$jvm_args"
 
 cd ../docs-tools
 


### PR DESCRIPTION
follow-up after https://github.com/elastic/logstash/pull/12763 is merged

have successfully tested  `./gradlew generatePluginsVersion` with 2g of heap, 
but let's not get overly optimistic :wink: