### PR TITLE
Add input-log4j to skiplist

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -6,6 +6,7 @@ skip:
   - logstash-devutils
   - logstash-output-hipchat # Incompatible with Logstash 5.x
   - logstash-output-jms # Incompatible with Logstash 5.x
+  - logstash-input-log4j # Deprecated in 5.x
   - logstash-codec-sflow # Empty plugin repository
   - logstash-filter-math # Empty plugin repository
   - logstash-input-mongodb # Empty plugin repository


### PR DESCRIPTION
Input-log4j was deprecated in 5.x. Recent restructuring in Beats documentation caused broken links in log4j. It doesn't make sense to release a new gem to a deprecated plugin. Instead, this PR adds input-log4j to the skiplist so that we won't pick up deprecations that I have to reverse each time we generate the plugin docs.  

Related: #45 #50

Note to self @karenzone and reviewer(s):  This updates one of three skiplists, and I hope it will solve the log4j regression problems.  Other skiplists: 
* Skiplist file - VPR: https://github.com/elastic/docs-tools/blob/master/versioned_plugins.rb
* Skiplist file - LSR: https://github.com/elastic/logstash/blob/master/rakelib/plugins-metadata.json

ToDo: Dig into other skiplist to see how they relate and if we can do some cleanup to avoid confusion.  Tracked in issue #50.