### PR TITLE
Fix asciidoc generation for aliased plugins

### DIFF
--- a/README.versioned_docs.md
+++ b/README.versioned_docs.md
@@ -3,6 +3,7 @@
 The versioned_plugins.rb ruby script crawls the github repositories of the "logstash-plugins" organization
 and generate the following structure:
 
+```
 docs/versioned-plugins
 ├── codecs
 │   ├── cef-index.asciidoc
@@ -24,10 +25,10 @@ docs/versioned-plugins
 │   ├── ruby-v3.1.3.asciidoc
 ├── filters-index.asciidoc
 ├── ...
-
+```
 #### Requirements
 
-* Ruby MRI 
+* Ruby MRI
 * Bundler
 * GitHub Personal Access Token with "public_repo" scope: https://github.com/settings/tokens/new
 * A clone of the logstash-docs repo: https://github.com/elastic/logstash-docs/

--- a/logstash/templates/docs/versioned-plugins/alias-index.asciidoc.erb
+++ b/logstash/templates/docs/versioned-plugins/alias-index.asciidoc.erb
@@ -1,4 +1,4 @@
-:plugin:  <%= alias_name %>
+:plugin: <%= alias_name %>
 :type: <%= type %>
 
 [id="{type}-{plugin}-index"]

--- a/logstash/templates/docs/versioned-plugins/alias-index.asciidoc.erb
+++ b/logstash/templates/docs/versioned-plugins/alias-index.asciidoc.erb
@@ -1,4 +1,4 @@
-:plugin:  <%= alias %>
+:plugin:  <%= alias_name %>
 :type: <%= type %>
 
 [id="{type}-{plugin}-index"]
@@ -9,7 +9,7 @@
 <titleabbrev>{plugin}</titleabbrev>
 ++++
 
-The `<%= type %>-<%= alias %>` plugin is the next generation of the
+The `<%= type %>-<%= alias_name %>` plugin is the next generation of the
 <<<%= type %>-<%= target %>-index,<%= type %>-<%= target %> plugin>>, and is based on the
 https://github.com/logstash-plugins/logstash-<%= type %>-<%= target %>[the same github repository].
 

--- a/logstash/templates/docs/versioned-plugins/alias-index.asciidoc.erb
+++ b/logstash/templates/docs/versioned-plugins/alias-index.asciidoc.erb
@@ -1,0 +1,17 @@
+:plugin:  <%= alias %>
+:type: <%= type %>
+
+[id="{type}-{plugin}-index"]
+
+== Versioned {plugin} {type} plugin
+[subs="attributes"]
+++++
+<titleabbrev>{plugin}</titleabbrev>
+++++
+
+The `<%= type %>-<%= alias %>` plugin is the next generation of the
+<<<%= type %>-<%= target %>-index,<%= type %>-<%= target %> plugin>>, and is based on the
+https://github.com/logstash-plugins/logstash-<%= type %>-<%= target %>[the same github repository].
+
+To see which plugin version you have installed, run
+`bin/logstash-plugin list --verbose`.

--- a/versioned_plugins.rb
+++ b/versioned_plugins.rb
@@ -434,9 +434,7 @@ class VersionedPluginDocs < Clamp::Command
   # param plugin_names_by_type: map of lists {:input => [beats, tcp, ...]}
   # return list of triples (type, alias, target) es: ("input", "agent", "beats")
   def load_alias_definitions_for_target_plugins(plugin_names_by_type)
-    alias_url = URI('https://raw.githubusercontent.com/elastic/logstash/275fd688e410534a34f0e173ab9eacf662bd9be5/logstash-core/src/main/resources/org/logstash/plugins/AliasRegistry.yml')
-    # TODO enable once PR https://github.com/elastic/logstash/pull/12841 has been merged on master
-    # alias_url = URI('https://raw.githubusercontent.com/elastic/logstash/master/logstash-core/src/main/resources/org/logstash/plugins/AliasRegistry.yml')
+    alias_url = URI('https://raw.githubusercontent.com/elastic/logstash/master/logstash-core/src/main/resources/org/logstash/plugins/AliasRegistry.yml')
     alias_yml = Net::HTTP.get(alias_url)
     yaml = YAML::safe_load(alias_yml) || {}
 

--- a/versioned_plugins.rb
+++ b/versioned_plugins.rb
@@ -404,8 +404,7 @@ class VersionedPluginDocs < Clamp::Command
 
   def write_versions_index(name, type, versions)
     output_asciidoc = "#{logstash_docs_path}/docs/versioned-plugins/#{type}s/#{name}-index.asciidoc"
-    directory = File.dirname(output_asciidoc)
-    FileUtils.mkdir_p(directory) if !File.directory?(directory)
+    lazy_create_output_folder(output_asciidoc)
     template = ERB.new(IO.read("logstash/templates/docs/versioned-plugins/plugin-index.asciidoc.erb"))
     content = template.result_with_hash(name: name, type: type, versions: versions)
     File.write(output_asciidoc, content)
@@ -414,8 +413,7 @@ class VersionedPluginDocs < Clamp::Command
   def write_type_index(type, plugins)
     template = ERB.new(IO.read("logstash/templates/docs/versioned-plugins/type.asciidoc.erb"))
     output_asciidoc = "#{logstash_docs_path}/docs/versioned-plugins/#{type}s-index.asciidoc"
-    directory = File.dirname(output_asciidoc)
-    FileUtils.mkdir_p(directory) if !File.directory?(directory)
+    lazy_create_output_folder(output_asciidoc)
     content = template.result_with_hash(type: type, plugins: plugins)
     File.write(output_asciidoc, content)
   end
@@ -451,7 +449,7 @@ class VersionedPluginDocs < Clamp::Command
         end
       end
     end
-    
+
     aliases
   end
 end


### PR DESCRIPTION
Meta-issue: https://github.com/elastic/logstash/issues/12793

This PR change the `versioned_plugins` doc tool to recreate the files as in PR https://github.com/elastic/logstash-docs/pull/1021/files.

Introduce new ERB template for alias indices, processes Logstash aliases definition yml file to produce the asciidoc files.

Fixes #53