### PR TITLE
fix: replace [source] only when stand-alone on line

### DIFF
--- a/versioned_plugins.rb
+++ b/versioned_plugins.rb
@@ -310,7 +310,7 @@ class VersionedPluginDocs < Clamp::Command
 
     if repair?
       content = content.gsub(/^====== /, "===== ")
-        .gsub("[source]", "[source,shell]")
+        .gsub(/^\[source\]$/, "[source,shell]")
         .gsub('[id="plugins-{type}-{plugin}', '[id="plugins-{type}s-{plugin}')
         .gsub(":include_path: ../../../logstash/docs/include", ":include_path: ../include/6.x")
         .gsub(/[\t\r ]+$/,"")


### PR DESCRIPTION
Many field references being added to docs as a part of the ECS effort
contain the literal string `[source]`, so we need to be more conservative
about which instances of `[source]` we replace with `[source,shell]`.

By matching a regular expression instead of a substring, we can match
only the instances of `[source]` that are stand-alone on a line.

Example 🤦🏼: https://www.elastic.co/guide/en/logstash-versioned-plugins/current/v6.2.0-plugins-inputs-tcp.html#v6.2.0-plugins-inputs-tcp-ecs_metadata