### PR TITLE
Update landing page text to remove extra word

### DIFF
--- a/logstash/templates/docs/versioned-plugins/alias-index.asciidoc.erb
+++ b/logstash/templates/docs/versioned-plugins/alias-index.asciidoc.erb
@@ -11,7 +11,7 @@
 
 The `<%= type %>-<%= alias_name %>` plugin is the next generation of the
 <<<%= type %>-<%= target %>-index,<%= type %>-<%= target %> plugin>>, and is based on the
-https://github.com/logstash-plugins/logstash-<%= type %>-<%= target %>[the same github repository].
+https://github.com/logstash-plugins/logstash-<%= type %>-<%= target %>[same github repository].
 
 To see which plugin version you have installed, run
 `bin/logstash-plugin list --verbose`.


### PR DESCRIPTION
Remove extra `the`. There's one in the actual text and one in the link text, and we don't need both. 