### PR TITLE
A doc generator implementation for aliased plugin.

### DIFF
--- a/aliased_plugin_doc_generator.rb
+++ b/aliased_plugin_doc_generator.rb
@@ -1,0 +1,47 @@
+
+require "clamp"
+
+require_relative 'lib/logstash-docket'
+
+class AliasedPluginDocGenerator < Clamp::Command
+  option "--path", "PATH", "The path aliased plugins located.", required: true
+  option "--alias-type", "ALIAS_TYPE", "Type of the alias to generate a doc.", required: true
+
+  ALIAS_PLUGINS = {
+    "beats" => {
+      "plugin_type" => "inputs",
+      "files" => {
+        "input_file" => "beats.asciidoc",
+        "output_file" => "elastic_agent.asciidoc"
+      },
+      "replaces" => {
+        ":plugin: beats" => ":plugin: elastic_agent",
+        ":plugin-uc: Beats" => ":plugin-uc: Elastic Agent",
+        ":plugin-singular: Beat" => ":plugin-singular: Elastic Agent"
+      }
+    }
+  }
+
+  def execute
+    if ALIAS_PLUGINS.include?alias_type
+      puts "Generating a doc for #{alias_type}.\n"
+
+      file_path = path + "/" + ALIAS_PLUGINS[alias_type]["plugin_type"] + "/"
+      input_file = file_path + ALIAS_PLUGINS[alias_type]["files"]["input_file"]
+      output_file = file_path + ALIAS_PLUGINS[alias_type]["files"]["output_file"]
+
+      puts "Input file: #{input_file}.\n"
+      content = File.read(input_file)
+      ALIAS_PLUGINS[alias_type]["replaces"].each { | key, value | content = content.gsub(key, value) }
+
+      puts "Output file: #{output_file}.\n"
+      File.write(output_file, content)
+    else
+      puts "Could not find a plugin for alias: #{alias_type}.\n"
+    end
+  end
+end
+
+if __FILE__ == $0
+  AliasedPluginDocGenerator.run
+end


### PR DESCRIPTION
## A doc generator for alias plugins.
### Description
This change automates manual job to create a doc for aliased plugins such as beats.

### Usage
Install the bundle
`bundle install --path=vendor/bundle`
Run generator
`bundle exec ruby aliased_plugin_doc_generator.rb --path=${{PATH}} --alias-type=${{ ALIAS_TYPE }}`

### Test
Cases:
- copy `beats.asciidoc` into repo dir and run generate command, `elastic_agent.asciidoc` is generated.
- `elastic_agent.asciidoc` is exist, run generate command by updating `beats.asciidoc`. Fresh `elastic_agent.asciidoc` is generated.
- call from [github workflow](https://github.com/mashhurs/logstash-docs/actions/runs/2012211872) and test fully automated flow.