### PR TITLE
Support stack versions in versioned plugin docs.

### DIFF
--- a/logstash/templates/docs/versioned-plugins/plugin-index.asciidoc.erb
+++ b/logstash/templates/docs/versioned-plugins/plugin-index.asciidoc.erb
@@ -1,5 +1,7 @@
 :plugin: <%= name %>
 :type: <%= type %>
+:branch: %BRANCH%
+:ecs_version: %ECS_VERSION%
 
 include::{include_path}/version-list-intro.asciidoc[]
 

--- a/versioned_plugins.rb
+++ b/versioned_plugins.rb
@@ -435,25 +435,25 @@ class VersionedPluginDocs < Clamp::Command
 
   def fetch_stack_versions
     stack_versions = Net::HTTP.get(URI.parse(VERSIONS_URL))
-    puts "Logstash version: #{get_logstash_version(stack_versions)}\n"
-    puts "ECS version: #{get_ecs_version(stack_versions)}\n"
+    @logstash_version = get_logstash_version(stack_versions)
+    puts "Logstash version: #{@logstash_version}\n"
+
+    @ecs_version = get_ecs_version(stack_versions)
+    puts "ECS version: #{@ecs_version}\n"
   end
 
   def get_logstash_version(stack_versions)
-    version = stack_versions[/\:logstash_version: (.*?)\n/, 1]
-    @logstash_version = version.strip unless version.nil?
+    stack_versions[/\:logstash_version:\s+(.*?)\n/, 1]
   end
 
   def get_ecs_version(stack_versions)
-    version = stack_versions[/\:ecs_version: (.*?)\n/, 1]
-    @ecs_version = version.strip unless version.nil?
+    stack_versions[/\:ecs_version:\s+(.*?)\n/, 1]
   end
 
   def write_stack_versions(content, type)
     # BRANCH and ECS_VERSION are newly added, will be available when every plugin index docs are re-indexed.
     # This is a backfill logic to add the fields after :type: entry
-    match = content.match(/\[":branch: %BRANCH%"\]/)
-    if (match.nil?)
+    if content =~ /\[":branch: %BRANCH%"\]/
       type_entry = ":type: #{type}\n"
       logstash_version_entry = ":branch: %BRANCH%\n"
       ecs_version_entry = ":ecs_version: %ECS_VERSION%\n"


### PR DESCRIPTION
## Overview
**Issue:** https://github.com/elastic/docs-tools/issues/46

When customers visit versioned plugin reference pages and go through the links to stack versions, they will be always forwarded to `current` stack version documents. This leads confusion ([example reported issue](https://github.com/elastic/elastic-docs-prototype/issues/133)) and not guiding customers properly, [example case](https://github.com/elastic/logstash-docs/pull/1289).

This PR suggests to add stack version to the VPR docs when new plugin releases happen so that we can easily use that version to forward the customers to proper stack version reference pages.

Closes #46 

## Test
- Tested locally by creating a [support-stack-versions-in-vpr-docs-test](https://github.com/mashhurs/docs-tools/tree/support-stack-versions-in-vpr-docs-test) branch under `mashhurs/doc-tools`. Then called in [`mashhurs/logstash-docs`](https://github.com/mashhurs/logstash-docs/actions/workflows/vpr.yml) VPR workflow.
- After running the VPR workflow, as a result, [test PR](https://github.com/mashhurs/logstash-docs/pull/1) is created.