### PR TITLE
Remove attribute settings from index template

### DIFF
--- a/logstash/templates/docs/versioned-plugins/plugin-index.asciidoc.erb
+++ b/logstash/templates/docs/versioned-plugins/plugin-index.asciidoc.erb
@@ -1,7 +1,5 @@
 :plugin: <%= name %>
 :type: <%= type %>
-:branch: %BRANCH%
-:ecs_version: %ECS_VERSION%
 
 include::{include_path}/version-list-intro.asciidoc[]
 


### PR DESCRIPTION
The attribute settings are causing the docs build to generate bogus content and are causing docs-ci to fail (with bad cross-document links).  Examples in https://github.com/elastic/logstash-docs/pull/1343, https://github.com/elastic/logstash-docs/pull/1344, and https://github.com/elastic/logstash-docs/pull/1345. 

We need to set the branch attributes for individual plugin version files (rather than in the index file) because the value will be different for different versions. I believe that the right fix will need to go in the applicable source files with conditional processing. (I'll handle that.) 

In the meantime, this fix _should_ stop the failures in the VPR docgen.
