### PR TITLE
Exclude logstash-integration-aws from versioned plugin docs

### DIFF
--- a/versioned_plugins.rb
+++ b/versioned_plugins.rb
@@ -29,7 +29,8 @@ class VersionedPluginDocs < Clamp::Command
     "logstash-input-java_input_example",
     "logstash-filter-java_filter_example",
     "logstash-output-java_output_example",
-    "logstash-codec-java_codec_example"
+    "logstash-codec-java_codec_example",
+    "logstash-integration-aws"
   ]
 
   STACK_VERSIONS_BASE_URL = "https://raw.githubusercontent.com/elastic/docs/master/shared/versions/stack/"


### PR DESCRIPTION
This plugin is still being built. Once it's fully merged and publish this commit should be reverted.