### PR TITLE
Integration plugin docs repeteadly genereted issue fix.

### DIFF
--- a/plugindocs.rb
+++ b/plugindocs.rb
@@ -14,7 +14,7 @@ class PluginDocs < Clamp::Command
   option "--output-path", "OUTPUT", "Path to the top-level of the logstash-docs path to write the output.", required: true
   option "--main", :flag, "Fetch the plugin's docs from main instead of the version found in PLUGINS_JSON", :default => false
   option "--settings", "SETTINGS_YAML", "Path to the settings file.", :default => File.join(File.dirname(__FILE__), "settings.yml"), :attribute_name => :settings_path
-  option("--parallelism", "NUMBER", "for performance", default: 1) { |v| Integer(v) }
+  option("--parallelism", "NUMBER", "for performance", default: 4) { |v| Integer(v) }
   option "--skip-existing", :flag, "Don't generate documentation if asciidoc file exists"
 
   parameter "PLUGINS_JSON", "The path to the file containing plugin versions json"

--- a/plugindocs.rb
+++ b/plugindocs.rb
@@ -13,7 +13,7 @@ class PluginDocs < Clamp::Command
   option "--output-path", "OUTPUT", "Path to the top-level of the logstash-docs path to write the output.", required: true
   option "--main", :flag, "Fetch the plugin's docs from main instead of the version found in PLUGINS_JSON", :default => false
   option "--settings", "SETTINGS_YAML", "Path to the settings file.", :default => File.join(File.dirname(__FILE__), "settings.yml"), :attribute_name => :settings_path
-  option("--parallelism", "NUMBER", "for performance", default: 4) { |v| Integer(v) }
+  option("--parallelism", "NUMBER", "for performance", default: 1) { |v| Integer(v) }
   option "--skip-existing", :flag, "Don't generate documentation if asciidoc file exists"
 
   parameter "PLUGINS_JSON", "The path to the file containing plugin versions json"


### PR DESCRIPTION
### Issue description
When generating Plugin Reference Docs, embedded integration plugin meta changes are not correctly picked up. #79 and #80 issues are relative.

#80 happens when logstash machine generates the doc first and re-tries to generate with `skip-existing` option. So unnecessary contents will appear for the second try.

Closes #79 
Closes #80 

### Acceptance criteria
Embedded plugin should follow the integration plugin and use its meta data in the docs.

### What does this PR introduce?
Logic generates the `plugins_version_docs.json` which contains the list of repositories with plugin details (default plugin and version, etc...). We iterate thought the repositories and generate the doc one-by-one for each plugin as well as plugin's dependencies (embedded and aliased plugins). There is a discrepancy which same job is repeated on same plugin with different information. Eg. the repository entry `integration-aws` doc generation includes `codec-cloudfront` embedded plugin and `integration-aws` info (version, change log URL, etc..) used for `codec-cloudfront` docs in same loop. However, when repository entry reaches `codec-cloudfront`, it also repeats doc generation with cloudfront's info (version, change log URL) which is the issue.
This PR introduces the a logic to avoid the repetition which was the bottleneck. 
Note that, for the short term we are making a process single since there will be a race condition on `processed_plugins` DS.

### Test
- Reproduces both cases on my local. Run to check with following command:
`bundle exec ruby plugindocs.rb --parallelism 1  --skip-existing --output-path ../logstash-docs ../logstash/plugins_version_docs.json`