### PR TITLE
Skip reindexing for integration plugins index

### DIFF
--- a/versioned_plugins.rb
+++ b/versioned_plugins.rb
@@ -209,8 +209,12 @@ class VersionedPluginDocs < Clamp::Command
     # rewrite versions-by-type indices
     $stderr.puts("REINDEXING TYPES... #{}\n")
     plugin_names_by_type.each do |type, names|
-      $stderr.puts("[type:#{type}] reindexing\n")
-      write_type_index(type, names.sort)
+      if type == 'integration'
+        $stderr.puts("[type:#{type}] skipping reindexing\n")
+      else
+        $stderr.puts("[type:#{type}] reindexing\n")
+        write_type_index(type, names.sort)
+      end
     end
   end
 


### PR DESCRIPTION
**Problem:** 
When adding a new integration plugin, the related plugin page in the Logstash ref links to a non-existent VPR docs landing page, causing broken links. Manually adding the landing page to the VPR docs doesn't currently work — it gets overwritten in the next VPR doc gen.

Example of this for an input plugin:

- Manually adds landing page: https://github.com/elastic/logstash-docs/pull/1021/files
- Landing page include gets overwritten: https://github.com/elastic/logstash-docs/commit/1ebe826daaea1a933b153db5ecbc6818fb6a07c0

**Solution:**
Update the `versioned_plugins.rb` to avoid overwriting the integration plugin index in the VPR docs. This lets us manually add landing pages for integration plugins to the VPR docs. However, this means we'll need to manually maintain [integrations-index.asciidoc](https://github.com/elastic/logstash-docs/blob/versioned_plugin_docs/docs/versioned-plugins/integrations-index.asciidoc?plain=1) going forward.

**Testing:**

1.  Check out the `main` branch locally.

1.  Run `versiond_plugins.rb` to generate the VPR docs:

    ```sh
    GITHUB_TOKEN=XXXXXXXXXXXXXX bundle exec ruby versioned_plugins.rb --output-path=<YOUR_PATH> --dry-run
    ```

1. Include a landing page in the `integrations-index.asciidoc` file in the generated `logstash-docs` repo. The landing page doesn't need to exist. Example:

    ```adoc
    ...
    include::integrations/rabbitmq-index.asciidoc[]

    include::integrations/just-another-index.asciidoc[]
    ```

1.  Check out this PR's branch locally.

1. Rerun `versiond_plugins.rb` script to regenerate the VPR docs. Use the same output path.

   ```sh
   GITHUB_TOKEN=XXXXXXXXXXXXXX bundle exec ruby versioned_plugins.rb --output-path=<YOUR_PATH> --dry-run
   ```

1.  Verify that `integrations-index.asciidoc` file in the generated `logstash-docs` repo wasn't overwritten. It should still contain your `include`. Example:

    ```adoc
    ...
    include::integrations/rabbitmq-index.asciidoc[]

    include::integrations/just-another-index.asciidoc[]
    ```
    
 **Related issue:**
 
 Closes https://github.com/elastic/docs-tools/issues/89