### PR TITLE
Enable auto-merge on autogen PRs

### DIFF
--- a/versioned_plugins.rb
+++ b/versioned_plugins.rb
@@ -244,8 +244,9 @@ class VersionedPluginDocs < Clamp::Command
       `git commit -m "updated versioned plugin docs" -a`
       `git push origin #{branch_name}`
     end
-    octo.create_pull_request("elastic/logstash-docs", "versioned_plugin_docs", branch_name,
+    pull_request = octo.create_pull_request("elastic/logstash-docs", "versioned_plugin_docs", branch_name,
         "auto generated update of versioned plugin documentation", "")
+    octo.update_pull_request("elastic/logstash-docs", pull_request.number, automerge: true)
   end
 
   def branch_exists?(client, branch_name)


### PR DESCRIPTION
**Problem:** PRs generated by the [`plugindocs.rb`](https://github.com/elastic/docs-tools/blob/main/plugindocs.rb) require a manual merge.

**Solution:** Update `plugindocs.rb` to auto-merge its PRs if required checks pass.

**Dependencies:** To work, this PR requires some GitHub setting updates for the `logstash-docs` repo:

- [ ] Require that PRs against the `versioned_plugin_docs` branch pass the `elasticsearch-ci/docs` check before merging. [[GitHub docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule#creating-a-branch-protection-rule)]
- [ ] Allow auto-merge. [[GitHub docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-auto-merge-for-pull-requests-in-your-repository#managing-auto-merge)]