### PR TITLE
A logic to generate an empty plugin placeholder. 

### DIFF
--- a/generate_plugin_placeholder.rb
+++ b/generate_plugin_placeholder.rb
@@ -3,10 +3,10 @@ require "erb"
 require "octokit"
 require_relative "git_helper"
 
-class GeneratePluginPlaceholder < Clamp::Command
-  option "--output-path", "OUTPUT", "Path to a directory where logstash-docs repository will be cloned and written to", required: true
+class GeneratePluginPlaceholderDoc < Clamp::Command
+  option "--output-path", "OUTPUT", "Path to a directory where logstash-docs repository is cloned and changes going to be written to", required: true
   option "--plugin-type", "STRING", "Type (ex: integration, input, etc) of a new plugin.", required: true
-  option "--plugin-name", "STRING", "Name for a new plugin.", required: true
+  option "--plugin-name", "STRING", "Name of the plugin.", required: true
 
   SUPPORTED_TYPES = %w(integration)
 
@@ -36,7 +36,9 @@ class GeneratePluginPlaceholder < Clamp::Command
   end
 
   def logstash_docs_path
-    File.join(output_path, "logstash-docs")
+    path = File.join(output_path, "logstash-docs")
+    fail("#{path} doesn't exist. Please provide the path for `--output-path` where `logstash-docs` repo is located.") unless Dir.exist?(path)
+    path
   end
 
   def submit_pr
@@ -49,10 +51,10 @@ class GeneratePluginPlaceholder < Clamp::Command
 
     pr_title = "A placeholder for new plugin"
     git_helper.commit(logstash_docs_path, branch_name, "create an empty placeholder for new plugin")
-    git_helper.create_pull_request(branch_name, "versioned_plugin_docs", pr_title, "")
+    git_helper.create_pull_request(branch_name, "versioned_plugin_docs", pr_title, "", { draft: true })
   end
 end
 
 if __FILE__ == $0
-  GeneratePluginPlaceholder.run
+  GeneratePluginPlaceholderDoc.run
 end

--- a/generate_plugin_placeholder.rb
+++ b/generate_plugin_placeholder.rb
@@ -43,7 +43,7 @@ class GeneratePluginPlaceholder < Clamp::Command
     branch_name = "new_plugin_placeholder"
     git_helper = GitHelper.new("elastic/logstash-docs")
     if git_helper.branch_exists?(branch_name)
-      puts "WARNING: Branch \"#{branch_name}\" already exists. Rejecting PR create process. Please merge the existing PR or delete the PR and the branch."
+      puts "WARNING: Branch \"#{branch_name}\" already exists. Aborting creation of PR. Please merge the existing PR or delete the PR and the branch."
       return
     end
 

--- a/generate_plugin_placeholder.rb
+++ b/generate_plugin_placeholder.rb
@@ -1,0 +1,58 @@
+require "clamp"
+require "erb"
+require "octokit"
+require_relative "git_helper"
+
+class GeneratePluginPlaceholder < Clamp::Command
+  option "--output-path", "OUTPUT", "Path to a directory where logstash-docs repository will be cloned and written to", required: true
+  option "--plugin-type", "STRING", "Type (ex: integration, input, etc) of a new plugin.", required: true
+  option "--plugin-name", "STRING", "Name for a new plugin.", required: true
+
+  SUPPORTED_TYPES = %w(integration)
+
+  def execute
+    generate_placeholder(plugin_type, plugin_name)
+    submit_pr
+  end
+
+  # adds an empty static page under the VPR
+  # this helps us to eliminate broken link issues in the docs
+  def generate_placeholder(type, name)
+    if type.nil? || name.nil?
+      $stderr.puts("Plugin type and name are required.")
+      return
+    end
+
+    unless SUPPORTED_TYPES.include?(type)
+      $stderr.puts("#{type} is not supported. Supported types are #{SUPPORTED_TYPES.inspect}")
+      return
+    end
+
+    placeholder_asciidoc = "#{logstash_docs_path}/docs/versioned-plugins/#{type}s/#{name}-index.asciidoc"
+    # changing template will fail to re-index the doc, do not change or keep consistent with VPR templates
+    template = ERB.new(IO.read("logstash/templates/docs/versioned-plugins/plugin-index.asciidoc.erb"))
+    content = template.result_with_hash(name: name, type: type, versions: [])
+    File.write(placeholder_asciidoc, content)
+  end
+
+  def logstash_docs_path
+    File.join(output_path, "logstash-docs")
+  end
+
+  def submit_pr
+    branch_name = "new_plugin_placeholder"
+    git_helper = GitHelper.new("elastic/logstash-docs")
+    if git_helper.branch_exists?(branch_name)
+      puts "WARNING: Branch \"#{branch_name}\" already exists. Rejecting PR create process. Please merge the existing PR or delete the PR and the branch."
+      return
+    end
+
+    pr_title = "A placeholder for new plugin"
+    git_helper.commit(logstash_docs_path, branch_name, "create an empty placeholder for new plugin")
+    git_helper.create_pull_request(branch_name, "versioned_plugin_docs", pr_title, "")
+  end
+end
+
+if __FILE__ == $0
+  GeneratePluginPlaceholder.run
+end

--- a/git_helper.rb
+++ b/git_helper.rb
@@ -5,12 +5,8 @@ class GitHelper
   attr_reader :git_client, :repo_name
 
   def initialize(repo_name)
-    using_gh_token = "using a github token"
-    if ENV.fetch("GITHUB_TOKEN", "").size > 0
-      puts using_gh_token
-    else
-      puts "not ".concat(using_gh_token)
-    end
+    print "not " if ENV.fetch("GITHUB_TOKEN", "").empty?
+    puts "using a github token"
 
     @git_client = Octokit::Client.new(:access_token => ENV["GITHUB_TOKEN"])
 

--- a/git_helper.rb
+++ b/git_helper.rb
@@ -24,9 +24,9 @@ class GitHelper
     end
   end
 
-  def create_pull_request(branch_name, against_branch, title, description)
+  def create_pull_request(branch_name, against_branch, title, description, options = {})
     puts "Creating a PR..."
-    @git_client.create_pull_request(@repo_name, against_branch, branch_name, title, description)
+    @git_client.create_pull_request(@repo_name, against_branch, branch_name, title, description, options)
   end
 
   def branch_exists?(branch_name)

--- a/git_helper.rb
+++ b/git_helper.rb
@@ -1,0 +1,42 @@
+require "octokit"
+
+class GitHelper
+
+  attr_reader :git_client, :repo_name
+
+  def initialize(repo_name)
+    using_gh_token = "using a github token"
+    if ENV.fetch("GITHUB_TOKEN", "").size > 0
+      puts using_gh_token
+    else
+      puts "not ".concat(using_gh_token)
+    end
+
+    @git_client = Octokit::Client.new(:access_token => ENV["GITHUB_TOKEN"])
+
+    fail("Repo name cannot be null or empty") if repo_name.nil? || repo_name.empty?
+    @repo_name = repo_name
+  end
+
+  def commit(repo_path, branch_name, commit_msg)
+    puts "Committing changes..."
+    Dir.chdir(repo_path) do |path|
+      `git checkout -b #{branch_name}`
+      `git add .`
+      `git commit -m "#{commit_msg}" -a`
+      `git push origin #{branch_name}`
+    end
+  end
+
+  def create_pull_request(branch_name, against_branch, title, description)
+    puts "Creating a PR..."
+    @git_client.create_pull_request(@repo_name, against_branch, branch_name, title, description)
+  end
+
+  def branch_exists?(branch_name)
+    @git_client.branch(@repo_name, branch_name)
+    true
+  rescue Octokit::NotFound
+    false
+  end
+end


### PR DESCRIPTION
### What does this PR?
- Adds a logic to generate an empty placeholder for new plugin
  - currently we have an use-case for integration plugin only;
  - it uses common template which later on can be used to fill released notes and dates;
- This change also adds a git helper to DRY.
  - git operations are used in both VPR docs generator and placeholder generator, so created a git helper to DRY;

### Test
- Generated sample: https://github.com/elastic/logstash-docs/pull/1536
- How to run locally?
  - Pull this change and run `ruby generate_plugin_placeholder.rb --output-path=/Users/mashhur/Dev/elastic --plugin-type=integration --plugin-name=testing` command

### Related issue
- Closes #90 