### PR TITLE
Enable generating docs on ls-integration plugin.

### DIFF
--- a/versioned_plugins.rb
+++ b/versioned_plugins.rb
@@ -30,8 +30,7 @@ class VersionedPluginDocs < Clamp::Command
     "logstash-input-java_input_example",
     "logstash-filter-java_filter_example",
     "logstash-output-java_output_example",
-    "logstash-codec-java_codec_example",
-    "logstash-integration-logstash"
+    "logstash-codec-java_codec_example"
   ]
 
   STACK_VERSIONS_BASE_URL = "https://raw.githubusercontent.com/elastic/docs/master/shared/versions/stack/"


### PR DESCRIPTION
### Description
After `logstash-integration-logstash` release, we need to enable docs generation on the plugin. This PR removes the plugin from the skip list to generate the docs.