### PR TITLE
Delete ci directory

### DIFF
--- a/ci/generate_versioned_docs.sh
+++ b/ci/generate_versioned_docs.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-bundle install
-bundle exec ruby versioned_plugins.rb --repair --skip-existing --output-path=$WORKSPACE/


### PR DESCRIPTION
Delete the CI directory and the generate_versioned_docs.sh script, as they are no longer needed due to https://github.com/elastic/logstash-docs/blob/main/.github/workflows/vpr.yml and https://github.com/elastic/infra/pull/39983/files

