### PR TITLE
Support plugin docs release outside of logstash-plugins org.

### DIFF
--- a/plugindocs.rb
+++ b/plugindocs.rb
@@ -150,10 +150,10 @@ class PluginDocs < Clamp::Command
   # Support for plugins that are sourced outside the logstash-plugins org,
   # by means of the gem_data's `source_code_uri` metadata.
   def github_source_from_gem_data(gem_name, gem_data)
-    known_source = gem_data.dig('source_code_uri')
+    known_source = gem_data.dig('metadata', 'source_code_uri')
 
     if known_source
-      known_source =~ %r{\bgithub\.com/(?<org>[^/])/(?<repo>[^/])} || fail("unsupported source `#{source}`")
+      known_source =~ %r{\bgithub.com/(?<org>[^/]+)/(?<repo>[^/]+)} || fail("unsupported source `#{known_source}`")
       org = Regexp.last_match(:org)
       repo = Regexp.last_match(:repo)
     else

--- a/versioned_plugins.rb
+++ b/versioned_plugins.rb
@@ -33,7 +33,9 @@ class VersionedPluginDocs < Clamp::Command
     "logstash-codec-java_codec_example"
   ]
 
-  ADDITIONAL_PLUGINS = [
+  # If plugins are under the logstash-plugins org, they will automatically explored.
+  # However, if plugin is located in other org, we need to manually list up here in a {org}/{plugin-repo-name} format.
+  ADDITIONAL_ORG_PLUGINS = [
     "elastic/logstash-filter-elastic_integration"
   ]
 
@@ -90,7 +92,7 @@ class VersionedPluginDocs < Clamp::Command
     repos = octo.org_repos("logstash-plugins")
     repos = repos.map {|repo| repo.name }.select {|repo| repo.match(plugin_regex) }
     repos = (repos - PLUGIN_SKIP_LIST).sort.uniq.map {|repo| "logstash-plugins/#{repo}"}
-    repos = repos.concat(ADDITIONAL_PLUGINS)
+    repos = repos.concat(ADDITIONAL_ORG_PLUGINS)
 
     puts "found #{repos.size} repos"
 

--- a/versioned_plugins.rb
+++ b/versioned_plugins.rb
@@ -33,6 +33,10 @@ class VersionedPluginDocs < Clamp::Command
     "logstash-codec-java_codec_example"
   ]
 
+  ADDITIONAL_PLUGINS = [
+    "elastic/logstash-filter-elastic_integration"
+  ]
+
   STACK_VERSIONS_BASE_URL = "https://raw.githubusercontent.com/elastic/docs/master/shared/versions/stack/"
 
   def logstash_docs_path
@@ -82,16 +86,17 @@ class VersionedPluginDocs < Clamp::Command
   end
 
   def generate_docs
-    regex = Regexp.new(plugin_regex)
     puts "writing to #{logstash_docs_path}"
     repos = octo.org_repos("logstash-plugins")
     repos = repos.map {|repo| repo.name }.select {|repo| repo.match(plugin_regex) }
     repos = (repos - PLUGIN_SKIP_LIST).sort.uniq.map {|repo| "logstash-plugins/#{repo}"}
+    repos = repos.concat(ADDITIONAL_PLUGINS)
 
     puts "found #{repos.size} repos"
 
     # TODO: make less convoluted
     timestamp_reference = since || Time.strptime($TIMESTAMP_REFERENCE, "%a, %d %b %Y %H:%M:%S %Z")
+    puts "Generating docs since #{timestamp_reference.inspect}"
 
     plugins_indexes_to_rebuild = Util::ThreadsafeWrapper.for(Set.new)
     package_indexes_to_rebuild = Util::ThreadsafeWrapper.for(Set.new)


### PR DESCRIPTION
## Description

We hadn't a case where plugin repo is located in outside of `logstash-plugins` org. We have now `elastic_integration` plugin which is under the `elastic` org. 

1) VPR:  adds `elastic_integration` plugin to the plugin list. We automatically discover plugins under `logstash-plugins` org and list up the skip plugins. Since `logstash-plugins` is controlled by Logstash team, we can easily make changes. However, this is not a case with `elastic` org. So, for now, I have hard coded the plugin and open to change for any other options (I am also thinking if there is a better way).

2) While investigating, I have found some issues need to be addressed before publishing the plugin docs:
- parsing source code uri from gemdata
We [fetch gem information from  `rubygems.org/api`](https://github.com/mashhurs/docs-tools/blob/1cae75ce5569e5511ef947e1e19c02ae74127930/lib/logstash-docket/rubygem_info.rb#L52) and use [the info for specific version](https://github.com/mashhurs/docs-tools/blob/1cae75ce5569e5511ef947e1e19c02ae74127930/lib/logstash-docket/rubygem_info.rb#L34). In the JSON data, our ROI is `source_code_uri` and it is located in the `metadata` field.
```json
// `https://rubygems.org/api/v1/versions/logstash-filter-elastic_integration.json` data
[
    {
        "authors": "Elastic",
        "built_at": "2023-10-04T00:00:00.000Z",
        "created_at": "2023-10-04T15:55:01.894Z",
        "description": "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program",
        "downloads_count": 447,
        "metadata": {
            "logstash_group": "filter",
            "logstash_plugin": "true",
            "source_code_uri": "https://github.com/elastic/logstash-filter-elastic_integration"
        },
        "number": "0.0.3",
        "summary": "Processes Elastic Integrations",
        "platform": "java",
        "rubygems_version": ">= 0",
        "ruby_version": ">= 0",
        "prerelease": false,
        "licenses": [
            "ELv2"
        ],
        "requirements": [],
        "sha": "79362e7df178884a838ff73c94840fc99a4980d56db37a3345d95cc571e8febe",
        "spec_sha": "74d9a1da51a6d56840da9a109d8051d0dbc8f93a9d5b3ed3bd3f830db3c42d0c"
    },
    ...
]
```

- regex pattern issue
 We somehow forgot to place `+` after the regex group bracket, ex: `?<org>[^/]+`

- failure message has unknown variable
`source` variable in the "unsupported source `#{source}`" doesn't exist, I assume we meant `known_source `


## How to test locally?
- pull changes
- Run `bundle exec ruby versioned_plugins.rb --repair --skip-existing --output-path=../ --since=2023-04-10` to see the plugin docs generated under `../logstash-docs` repo which should be already cloned in your env. Note that, we are attaching `--since=2023-04-10` to see `elastic_integration` changes. Any new version of plugin will be caught without using `--since`

### History
- current `elastic_integration` plugin repo is private. We will make it public soon. So, you will need to manually set your PAT to get the recent plugin doc from the private repo. Replace `Github#read_file` of the `logstash-docket/source.rb` fiel with following source and replace `myGhPat` with your GH token.

```
# logstash-docket/source.rb

def read_file(filename, version=nil)
        require 'net/https'
        require 'uri'
        
        uri = URI.parse("https://raw.githubusercontent.com/#{org}/#{repo}/#{ref(version)}/#{filename}")

        http = Net::HTTP.new(uri.host, uri.port)
        http.use_ssl = true

        headers = { "Authorization" => "Bearer myGhPat" }
        request = Net::HTTP::Get.new(uri.request_uri, headers)
        response = http.request(request).body

        return nil if response.start_with?('404: Not Found')
        response
end
```
- Run `bundle exec ruby versioned_plugins.rb --repair --skip-existing --output-path=../ --since=2023-04-10` to see the plugin docs generated under `../logstash-docs` repo which should be already cloned in your env.