### PR TITLE
Adjust docs tooling for integration plugins

### DIFF
--- a/plugindocs.rb
+++ b/plugindocs.rb
@@ -63,11 +63,6 @@ class PluginDocs < Clamp::Command
         github_source_from_gem_data(repository_name, gem_data)
       end || fail("[repository:#{repository_name}]: failed to find release package `#{tag(version)}` via rubygems")
 
-      if released_plugin.type == 'integration' && !is_default_plugin
-        $stderr.puts("[repository:#{repository_name}]: Skipping non-default Integration Plugin\n")
-        next
-      end
-
       release_tag = released_plugin.tag
       release_date = released_plugin.release_date ?
                        released_plugin.release_date.strftime("%Y-%m-%d") :


### PR DESCRIPTION
### Related: 
* #106
* https://github.com/elastic/logstash/pull/16174 

### Change to processing logic for integration plugins.

We have a situation in which we are moving an integration plugin into Technical Preview before we bundle it with Logstash by default.  We need the ability to process those docs. 

