### PR TITLE
Persist last workflow run time and reference in next runs.

### DIFF
--- a/versioned_plugins.rb
+++ b/versioned_plugins.rb
@@ -95,8 +95,8 @@ class VersionedPluginDocs < Clamp::Command
     @doc_generated_last_time_reference ||= begin
                                              if since
                                                since
-                                             elsif File.exist?(PLUGIN_DOCS_LAST_GENERATED_FILE)
-                                               Time.parse(File.read(PLUGIN_DOCS_LAST_GENERATED_FILE).strip)
+                                             elsif File.exist?(get_docs_last_generated_file_path)
+                                               Time.parse(File.read(get_docs_last_generated_file_path).strip)
                                              else
                                                Time.strptime($TIMESTAMP_REFERENCE, "%a, %d %b %Y %H:%M:%S %Z")
                                              end
@@ -486,14 +486,18 @@ class VersionedPluginDocs < Clamp::Command
 
   PLUGIN_DOCS_LAST_GENERATED_FILE = "plugin_docs_last_generated_time.txt"
 
+  def get_docs_last_generated_file_path
+    "#{logstash_docs_path}/#{PLUGIN_DOCS_LAST_GENERATED_FILE}"
+  end
+
   # Save doc generated time, next time will be used for fetching plugins from this time
   # Note that if we base on last commit time, PR merge creates new commit where we lose plugin docs between PR creation and merge
   def save_doc_generated_time
     # Create if it doesn't exist
-    File.new(PLUGIN_DOCS_LAST_GENERATED_FILE, "w") unless File.exist?(PLUGIN_DOCS_LAST_GENERATED_FILE)
+    File.new(get_docs_last_generated_file_path, "w") unless File.exist?(get_docs_last_generated_file_path)
 
     # Overwrite file with the resolved last docs generated timestamp
-    File.open(PLUGIN_DOCS_LAST_GENERATED_FILE, "w") do |file|
+    File.open(get_docs_last_generated_file_path, "w") do |file|
       file.puts "#{@doc_generated_last_time_reference}"
     end
   end

--- a/versioned_plugins.rb
+++ b/versioned_plugins.rb
@@ -58,9 +58,11 @@ class VersionedPluginDocs < Clamp::Command
     check_rate_limit!
     clone_docs_repo
     fetch_stack_versions
+    resolve_reference_timestamp
     generate_docs
     if new_versions?
       unless dry_run?
+        save_doc_generated_time
         puts "creating pull request.."
         submit_pr
       end
@@ -87,6 +89,20 @@ class VersionedPluginDocs < Clamp::Command
     end
   end
 
+  # Tries to get last doc generated time from the file unless since
+  # For the worst case, fallbacks to the last commit time
+  def resolve_reference_timestamp
+    @doc_generated_last_time_reference ||= begin
+                                             if since
+                                               since
+                                             elsif File.exist?(PLUGIN_DOCS_LAST_GENERATED_FILE)
+                                               Time.parse(File.read(PLUGIN_DOCS_LAST_GENERATED_FILE).strip)
+                                             else
+                                               Time.strptime($TIMESTAMP_REFERENCE, "%a, %d %b %Y %H:%M:%S %Z")
+                                             end
+                                           end
+  end
+
   def generate_docs
     puts "writing to #{logstash_docs_path}"
     repos = octo.org_repos("logstash-plugins")
@@ -95,10 +111,7 @@ class VersionedPluginDocs < Clamp::Command
     repos = repos.concat(ADDITIONAL_ORG_PLUGINS)
 
     puts "found #{repos.size} repos"
-
-    # TODO: make less convoluted
-    timestamp_reference = since || Time.strptime($TIMESTAMP_REFERENCE, "%a, %d %b %Y %H:%M:%S %Z")
-    puts "Generating docs since #{timestamp_reference.inspect}"
+    puts "Generating docs since #{@doc_generated_last_time_reference.inspect}"
 
     plugins_indexes_to_rebuild = Util::ThreadsafeWrapper.for(Set.new)
     package_indexes_to_rebuild = Util::ThreadsafeWrapper.for(Set.new)
@@ -127,14 +140,14 @@ class VersionedPluginDocs < Clamp::Command
         next
       end
 
-      # if the repository has no releases, or none since our `timestamp_reference`,
+      # if the repository has no releases, or none since our `@doc_generated_last_time_reference`,
       # it doesn't need to be added to the reindex list here.
-      if latest_release.release_date.nil? || latest_release.release_date < timestamp_reference
+      if latest_release.release_date.nil? || latest_release.release_date < @doc_generated_last_time_reference
         $stderr.puts("#{repository.desc}: no new releases.\n")
         next
       end
 
-      # the repository has one or more releases since our `timestamp_reference`, which means
+      # the repository has one or more releases since our `@doc_generated_last_time_reference`, which means
       # it will need to be reindexed.
       $stderr.puts("#{repository.desc}: found new release\n")
       # repos_requiring_rebuild.add(repository.name) &&
@@ -471,6 +484,19 @@ class VersionedPluginDocs < Clamp::Command
       .gsub("%ECS_VERSION%", @ecs_version)
   end
 
+  PLUGIN_DOCS_LAST_GENERATED_FILE = "plugin_docs_last_generated_time.txt"
+
+  # Save doc generated time, next time will be used for fetching plugins from this time
+  # Note that if we base on last commit time, PR merge creates new commit where we lose plugin docs between PR creation and merge
+  def save_doc_generated_time
+    # Create if it doesn't exist
+    File.new(PLUGIN_DOCS_LAST_GENERATED_FILE, "w") unless File.exist?(PLUGIN_DOCS_LAST_GENERATED_FILE)
+
+    # Overwrite file with the resolved last docs generated timestamp
+    File.open(PLUGIN_DOCS_LAST_GENERATED_FILE, "w") do |file|
+      file.puts "#{@doc_generated_last_time_reference}"
+    end
+  end
 end
 
 if __FILE__ == $0

--- a/versioned_plugins.rb
+++ b/versioned_plugins.rb
@@ -95,8 +95,8 @@ class VersionedPluginDocs < Clamp::Command
     @doc_generated_last_time_reference ||= begin
                                              if since
                                                since
-                                             elsif File.exist?(get_docs_last_generated_file_path)
-                                               Time.parse(File.read(get_docs_last_generated_file_path).strip)
+                                             elsif File.exist?(PLUGIN_DOCS_LAST_GENERATED_FILE)
+                                               Time.parse(File.read(PLUGIN_DOCS_LAST_GENERATED_FILE).strip)
                                              else
                                                Time.strptime($TIMESTAMP_REFERENCE, "%a, %d %b %Y %H:%M:%S %Z")
                                              end
@@ -484,20 +484,13 @@ class VersionedPluginDocs < Clamp::Command
       .gsub("%ECS_VERSION%", @ecs_version)
   end
 
-  PLUGIN_DOCS_LAST_GENERATED_FILE = "plugin_docs_last_generated_time.txt"
-
-  def get_docs_last_generated_file_path
-    "#{logstash_docs_path}/#{PLUGIN_DOCS_LAST_GENERATED_FILE}"
-  end
+  PLUGIN_DOCS_LAST_GENERATED_FILE = "#{logstash_docs_path}/#{PLUGIN_DOCS_LAST_GENERATED_FILE}"
 
   # Save doc generated time, next time will be used for fetching plugins from this time
   # Note that if we base on last commit time, PR merge creates new commit where we lose plugin docs between PR creation and merge
   def save_doc_generated_time
-    # Create if it doesn't exist
-    File.new(get_docs_last_generated_file_path, "w") unless File.exist?(get_docs_last_generated_file_path)
-
     # Overwrite file with the resolved last docs generated timestamp
-    File.open(get_docs_last_generated_file_path, "w") do |file|
+    File.open(PLUGIN_DOCS_LAST_GENERATED_FILE, "w") do |file|
       file.puts "#{@doc_generated_last_time_reference}"
     end
   end


### PR DESCRIPTION
### Description

See https://github.com/elastic/docs-tools/issues/115 to understand the issue.
This PR persists the last docs generated time into file and uses it for the next runs. It eliminates the issue where plugins docs missed when there is outstanding PR in logstash-docs.


### How to test?
We simulate https://github.com/elastic/logstash-docs/blob/main/.github/workflows/vpr.yml in our local env.
- Clone logstash-docs repo, checkout `versioned_plugin_docs` branch
- Pull this change and execute `bundle exec ruby versioned_plugins.rb --repair --skip-existing --dry-run --output-path=../ `. Note that `output-path` should be `logstash-docs` path