### PR TITLE
Fix undefined local var or method logstash_docs_path error.

### DIFF
--- a/versioned_plugins.rb
+++ b/versioned_plugins.rb
@@ -95,8 +95,8 @@ class VersionedPluginDocs < Clamp::Command
     @doc_generated_last_time_reference ||= begin
                                              if since
                                                since
-                                             elsif File.exist?(PLUGIN_DOCS_LAST_GENERATED_FILE)
-                                               Time.parse(File.read(PLUGIN_DOCS_LAST_GENERATED_FILE).strip)
+                                             elsif File.exist?(get_last_generated_file_path)
+                                               Time.parse(File.read(get_last_generated_file_path).strip)
                                              else
                                                Time.strptime($TIMESTAMP_REFERENCE, "%a, %d %b %Y %H:%M:%S %Z")
                                              end
@@ -484,7 +484,11 @@ class VersionedPluginDocs < Clamp::Command
       .gsub("%ECS_VERSION%", @ecs_version)
   end
 
-  PLUGIN_DOCS_LAST_GENERATED_FILE = "#{logstash_docs_path}/plugin_docs_last_generated_time.txt"
+  PLUGIN_DOCS_LAST_GENERATED_FILE = "plugin_docs_last_generated_time.txt"
+
+  def get_last_generated_file_path
+    "#{logstash_docs_path}/#{PLUGIN_DOCS_LAST_GENERATED_FILE}"
+  end
 
   # Save doc generated time, next time will be used for fetching plugins from this time
   # Note that if we base on last commit time, PR merge creates new commit where we lose plugin docs between PR creation and merge

--- a/versioned_plugins.rb
+++ b/versioned_plugins.rb
@@ -95,8 +95,8 @@ class VersionedPluginDocs < Clamp::Command
     @doc_generated_last_time_reference ||= begin
                                              if since
                                                since
-                                             elsif File.exist?(get_last_generated_file_path)
-                                               Time.parse(File.read(get_last_generated_file_path).strip)
+                                             elsif File.exist?(plugin_docs_last_generated_file)
+                                               Time.parse(File.read(plugin_docs_last_generated_file).strip)
                                              else
                                                Time.strptime($TIMESTAMP_REFERENCE, "%a, %d %b %Y %H:%M:%S %Z")
                                              end
@@ -484,7 +484,7 @@ class VersionedPluginDocs < Clamp::Command
       .gsub("%ECS_VERSION%", @ecs_version)
   end
 
-  def get_last_generated_file_path
+  def plugin_docs_last_generated_file
     "#{logstash_docs_path}/plugin_docs_last_generated_time.txt"
   end
 
@@ -492,7 +492,7 @@ class VersionedPluginDocs < Clamp::Command
   # Note that if we base on last commit time, PR merge creates new commit where we lose plugin docs between PR creation and merge
   def save_doc_generated_time
     # Overwrite file with the resolved last docs generated timestamp
-    File.open(get_last_generated_file_path, "w") do |file|
+    File.open(plugin_docs_last_generated_file, "w") do |file|
       file.puts "#{@doc_generated_last_time_reference}"
     end
   end

--- a/versioned_plugins.rb
+++ b/versioned_plugins.rb
@@ -494,7 +494,7 @@ class VersionedPluginDocs < Clamp::Command
   # Note that if we base on last commit time, PR merge creates new commit where we lose plugin docs between PR creation and merge
   def save_doc_generated_time
     # Overwrite file with the resolved last docs generated timestamp
-    File.open(PLUGIN_DOCS_LAST_GENERATED_FILE, "w") do |file|
+    File.open(get_last_generated_file_path, "w") do |file|
       file.puts "#{@doc_generated_last_time_reference}"
     end
   end

--- a/versioned_plugins.rb
+++ b/versioned_plugins.rb
@@ -484,10 +484,8 @@ class VersionedPluginDocs < Clamp::Command
       .gsub("%ECS_VERSION%", @ecs_version)
   end
 
-  PLUGIN_DOCS_LAST_GENERATED_FILE = "plugin_docs_last_generated_time.txt"
-
   def get_last_generated_file_path
-    "#{logstash_docs_path}/#{PLUGIN_DOCS_LAST_GENERATED_FILE}"
+    "#{logstash_docs_path}/plugin_docs_last_generated_time.txt"
   end
 
   # Save doc generated time, next time will be used for fetching plugins from this time


### PR DESCRIPTION
It looks with the variable which contains the method will through the error. We are getting the following error in the workflow -https://github.com/elastic/logstash-docs/actions/runs/17774774475/job/50519641319

```
Run bundle exec ruby versioned_plugins.rb --repair --skip-existing --output-path=../
/home/runner/.rubies/jruby-10.0.2.0/lib/ruby/gems/shared/gems/octokit-4.21.0/lib/octokit/client.rb:24: warning: base64 was loaded from the standard library, but is not part of the default gems starting from Ruby 3.4.0.
You can add base64 to your Gemfile or gemspec to silence this warning.
NameError: undefined local variable or method 'logstash_docs_path' for class VersionedPluginDocs
  <module:VersionedPluginDocs> at versioned_plugins.rb:487
                        <main> at versioned_plugins.rb:14
```